### PR TITLE
Add DELETE support for use with the Duo Admin API

### DIFF
--- a/lib/duo-api.rb
+++ b/lib/duo-api.rb
@@ -31,6 +31,10 @@ module DuoApi
     client.post(*args)
   end
 
+  def self.delete(*args)
+    client.delete(*args)
+  end
+
   def self.request(*args)
     client.request(*args)
   end

--- a/lib/duo-api/client.rb
+++ b/lib/duo-api/client.rb
@@ -28,6 +28,10 @@ module DuoApi
       Request.request(self, path, { :method => "POST" }.merge(options))
     end
 
+    def delete(path, options = {})
+      Request.request(self, path, { :method => "DELETE" }.merge(options))
+    end
+
     def sign(user_key)
       signer.sign(user_key)
     end

--- a/lib/duo-api/request.rb
+++ b/lib/duo-api/request.rb
@@ -1,5 +1,6 @@
 require "net/http"
 require "time"
+require "erb"
 require "duo-api/header_signature"
 require "duo-api/response"
 require "duo-api/util"
@@ -31,7 +32,7 @@ module DuoApi
       params = stringify_hash(params)
       @query_string = params.
         sort_by { |k| k }.
-        map {|k,v| "#{URI.encode(k.to_s)}=#{URI.encode(v.to_s)}" }.
+        map {|k,v| "#{ERB::Util.url_encode(k.to_s)}=#{ERB::Util.url_encode(v.to_s)}" }.
         join("&")
 
       @signature = HeaderSignature.new(client, method, path, query_string)

--- a/lib/duo-api/request.rb
+++ b/lib/duo-api/request.rb
@@ -93,6 +93,8 @@ module DuoApi
           Net::HTTP::Get
         when "POST"
           Net::HTTP::Post
+        when "DELETE"
+          Net::HTTP::Delete
         end
       end
   end

--- a/lib/duo-api/version.rb
+++ b/lib/duo-api/version.rb
@@ -1,3 +1,3 @@
 module DuoApi
-  VERSION = "0.2.1"
+  VERSION = "0.3.0"
 end

--- a/spec/duo-api_spec.rb
+++ b/spec/duo-api_spec.rb
@@ -25,6 +25,12 @@ describe DuoApi do
     DuoApi.post("/auth/v2/check")
   end
 
+  it "sends delete to Request" do
+    expect(DuoApi::Request).to receive(:request)
+
+    DuoApi.delete("/auth/v2/check")
+  end
+
   it "signs" do
     expect(DuoApi.sign("jphenow")).to be_a String
   end


### PR DESCRIPTION
Some operations against Duo's Admin API use the HTTP DELETE method. These include disassociating users from groups, tokens, phones, etc., along with (obviously) deleting any of those entities. Cf. https://duo.com/support/documentation/adminapi#disassociate-group-from-user

This adds support for the full Admin API by adding a delete method. I also bumped the version number; let me know if you'd like me to resubmit without that change, or if anything else is needed.

Thanks!
